### PR TITLE
Update past `embassy-time` split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "ba67f6d3a8c84262fcc9b2020670515d192555f1" }
-embassy-util = { git = "https://github.com/embassy-rs/embassy.git", rev = "ba67f6d3a8c84262fcc9b2020670515d192555f1" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "aefa5275a2ab2cac6caef599e7adb76ce1beeddd" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "aefa5275a2ab2cac6caef599e7adb76ce1beeddd" }
+embassy-util = { git = "https://github.com/embassy-rs/embassy.git", rev = "aefa5275a2ab2cac6caef599e7adb76ce1beeddd" }

--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 
 [dependencies]
 embassy-executor = { version = "0.1.0", default-features = false, features = ["nightly"] }
+embassy-time = { version = "0.1.0", optional = true, default-features = false, features = ["nightly"] }
 embassy-util = { version = "0.1.0", default-features = false, features = ["nightly"] }
 atomic-polyfill = "0.1"
 
@@ -33,10 +34,12 @@ embedded-hal-async = { version = "0.1.0-alpha.1" }
 futures = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-embassy-executor = { version = "0.1.0", features = ["std", "time", "time-tick-1mhz"]}
+embassy-executor = { version = "0.1.0", features = ["std", "integrated-timers"]}
+embassy-time = { version = "0.1.0", default-features = false, features = ["nightly", "tick-1mhz"] }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
+critical-section = { version = "1.1" }
 
 [features]
 default = [ "std", "log", "time" ]
-std = ["embassy-executor/std", "embassy-executor/time"]
+std = ["embassy-executor/std", "embassy-executor/integrated-timers", "embassy-time/std", "critical-section/std"]
 time = []

--- a/ector/examples/pingpong.rs
+++ b/ector/examples/pingpong.rs
@@ -3,14 +3,14 @@
 #![feature(type_alias_impl_trait)]
 
 use ector::*;
-use embassy_executor::time::{Duration, Ticker};
+use embassy_time::{Duration, Ticker};
 use futures::{
     future::{select, Either},
     pin_mut, StreamExt,
 };
 
 #[embassy_executor::main]
-async fn main(s: embassy_executor::executor::Spawner) {
+async fn main(s: embassy_executor::Spawner) {
     // Example of circular references
     static PINGER: ActorContext<Pinger> = ActorContext::new();
     static PONGER: ActorContext<Ponger> = ActorContext::new();

--- a/ector/examples/request.rs
+++ b/ector/examples/request.rs
@@ -3,10 +3,10 @@
 #![feature(type_alias_impl_trait)]
 
 use ector::*;
-use embassy_executor::time::{Duration, Timer};
+use embassy_time::{Duration, Timer};
 
 #[embassy_executor::main]
-async fn main(s: embassy_executor::executor::Spawner) {
+async fn main(s: embassy_executor::Spawner) {
     // Example of request response
     static SERVER: ActorContext<Server> = ActorContext::new();
 

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -5,7 +5,7 @@ use embassy_util::{
     blocking_mutex::raw::NoopRawMutex,
     channel::mpmc::{Channel, DynamicSender, Receiver, TrySendError},
 };
-use embassy_executor::executor::{raw::TaskStorage as Task, SpawnError, Spawner};
+use embassy_executor::{raw::TaskStorage as Task, SpawnError, Spawner};
 
 type ActorMutex = NoopRawMutex;
 

--- a/ector/src/testutil.rs
+++ b/ector/src/testutil.rs
@@ -288,13 +288,13 @@ impl Default for TestRunner {
 
 impl TestRunner {
     pub fn initialize(&'static self, init: impl FnOnce(Spawner)) {
-        init(unsafe { (&*self.inner.get()).spawner() });
+        init(unsafe { (*self.inner.get()).spawner() });
     }
 
     pub fn run_until_idle(&'static self) {
         self.signaler.prepare();
         while self.signaler.should_run() {
-            unsafe { (&*self.inner.get()).poll() };
+            unsafe { (*self.inner.get()).poll() };
         }
     }
 

--- a/ector/src/testutil.rs
+++ b/ector/src/testutil.rs
@@ -4,7 +4,7 @@ use core::cell::RefCell;
 use core::future::Future;
 use core::pin::Pin;
 use embassy_util::channel::signal::Signal;
-use embassy_executor::executor::{raw, raw::TaskStorage as Task, SpawnError, Spawner};
+use embassy_executor::{raw, raw::TaskStorage as Task, SpawnError, Spawner};
 use embassy_util::Forever;
 use embedded_hal::digital::v2::InputPin;
 use embedded_hal_async::digital::Wait;

--- a/ector/tests/integration_tests.rs
+++ b/ector/tests/integration_tests.rs
@@ -6,7 +6,7 @@
 mod tests {
     use core::future::Future;
     use ector::*;
-    use embassy_executor::executor::Spawner;
+    use embassy_executor::Spawner;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::{sync::mpsc, thread, time::Duration};
 

--- a/macros/src/actor.rs
+++ b/macros/src/actor.rs
@@ -110,7 +110,7 @@ pub(crate) fn generate_actor(input: &mut Item) {
     input.items.push(ImplItem::Type(on_mount_future));
 
     let mut lifetimes = CollectLifetimes::new("'impl", input.impl_token.span);
-    lifetimes.visit_type_mut(&mut *input.self_ty);
+    lifetimes.visit_type_mut(&mut input.self_ty);
     lifetimes.visit_path_mut(&mut input.trait_.as_mut().unwrap().1);
     let params = &input.generics.params;
     let elided = lifetimes.elided;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2022-05-24"
+channel = "nightly-2022-08-19"
 components = ["clippy"]


### PR DESCRIPTION
I'm afraid Embassy just did it again, they split off `time` into its own `embassy-time` crate.