### PR TITLE
Feature gate the embedded hal dependencies behind "test-util" feature

### DIFF
--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -23,9 +23,9 @@ log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
 
 ector-macros = { version = "0.1.1", path = "../macros" }
-embedded-hal = { version = "0.2", features = ["unproven"] }
-embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.9"}
-embedded-hal-async = { version = "=0.1.0-alpha.3" }
+embedded-hal = { version = "0.2", features = ["unproven"], optional = true }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.9", optional = true }
+embedded-hal-async = { version = "=0.1.0-alpha.3", optional = true }
 futures = { version = "0.3", default-features = false }
 static_cell = "1.0.0"
 
@@ -38,4 +38,5 @@ critical-section = { version = "1.1", features = ["std"] }
 [features]
 default = [ "std", "log", "time" ]
 std = ["embassy-executor/std", "embassy-executor/integrated-timers", "embassy-time/std", "critical-section/std"]
+test-util = [ "dep:embedded-hal", "dep:embedded-hal-1", "dep:embedded-hal-async"]
 time = []

--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -34,6 +34,7 @@ embassy-executor = { version = "0.1.0", default-features = false, features = ["s
 embassy-time = { version = "0.1.0", default-features = false, features = ["std", "nightly"] }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 critical-section = { version = "1.1", features = ["std"] }
+ector = { path = ".", features = ["std", "log", "time", "test-util"] }
 
 [features]
 default = [ "std", "log", "time" ]

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -11,7 +11,7 @@ mod actor;
 
 pub use {actor::*, ector_macros::*};
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "test-util"))]
 pub mod testutil;
 
 /// Spawn an actor given a spawner and the actors name, type and instance.


### PR DESCRIPTION
Put the `test-util` module behind a feature gate and the dependencies of the embedded-hal so the crate  can be used with other versions of the e-h.