### PR TITLE
Feat/different mutex support

### DIFF
--- a/ector/examples/macro-usage.rs
+++ b/ector/examples/macro-usage.rs
@@ -1,0 +1,49 @@
+#![macro_use]
+#![feature(type_alias_impl_trait)]
+
+use ector::{
+    mutex::{CriticalSectionRawMutex, NoopRawMutex},
+    *,
+};
+use embassy_time::{Duration, Timer};
+
+#[embassy_executor::main]
+async fn main(s: embassy_executor::Spawner) {
+    let server_1 = spawn_actor!(s, SERVER_1, Server, Server);
+    let server_2 = spawn_actor!(s, SERVER_2, Server, Server, CriticalSectionRawMutex);
+    let server_3 = spawn_actor!(s, SERVER_3, Server, Server, 2);
+    let server_4 = spawn_actor!(s, SERVER_4, Server, Server, CriticalSectionRawMutex, 2);
+
+    let servers = [server_1, server_2, server_3, server_4];
+    loop {
+        for (i, server) in servers.iter().enumerate() {
+            let r = server.request("Hello").await;
+            println!("Server {} returned {}", i, r);
+            Timer::after(Duration::from_secs(1)).await;
+        }
+    }
+}
+
+pub struct Server;
+
+unsafe impl Send for Server {}
+
+#[actor]
+impl Actor for Server {
+    type Message<'m> = Request<&'static str, &'static str, CriticalSectionRawMutex>;
+    async fn on_mount<M>(
+        &mut self,
+        _: Address<Request<&'static str, &'static str, CriticalSectionRawMutex>>,
+        mut inbox: M,
+    ) where
+        M: Inbox<Self::Message<'m>> + 'm,
+    {
+        println!("Server started!");
+
+        loop {
+            let motd = inbox.next().await;
+            let m = motd.as_ref().clone();
+            motd.reply(m).await;
+        }
+    }
+}

--- a/ector/examples/macro-usage.rs
+++ b/ector/examples/macro-usage.rs
@@ -1,10 +1,7 @@
 #![macro_use]
 #![feature(type_alias_impl_trait)]
 
-use ector::{
-    mutex::{CriticalSectionRawMutex, NoopRawMutex},
-    *,
-};
+use ector::{mutex::CriticalSectionRawMutex, *};
 use embassy_time::{Duration, Timer};
 
 #[embassy_executor::main]
@@ -25,8 +22,6 @@ async fn main(s: embassy_executor::Spawner) {
 }
 
 pub struct Server;
-
-unsafe impl Send for Server {}
 
 #[actor]
 impl Actor for Server {

--- a/ector/examples/macro-usage.rs
+++ b/ector/examples/macro-usage.rs
@@ -14,7 +14,7 @@ async fn main(s: embassy_executor::Spawner) {
     let servers = [server_1, server_2, server_3, server_4];
     loop {
         for (i, server) in servers.iter().enumerate() {
-            let r = server.request("Hello").await;
+            let r = server.request("Hello".to_string()).await;
             println!("Server {} returned {}", i, r);
             Timer::after(Duration::from_secs(1)).await;
         }
@@ -25,10 +25,10 @@ pub struct Server;
 
 #[actor]
 impl Actor for Server {
-    type Message<'m> = Request<&'static str, &'static str, CriticalSectionRawMutex>;
+    type Message<'m> = Request<String, String, CriticalSectionRawMutex>;
     async fn on_mount<M>(
         &mut self,
-        _: Address<Request<&'static str, &'static str, CriticalSectionRawMutex>>,
+        _: Address<Request<String, String, CriticalSectionRawMutex>>,
         mut inbox: M,
     ) where
         M: Inbox<Self::Message<'m>> + 'm,

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -270,21 +270,13 @@ where
     }
 
     /// Mount the underlying actor and initialize the channel.
-    pub fn mount_send<S: SendActorSpawner>(
+    pub fn mount_send<'a, S: SendActorSpawner>(
         &'static self,
         spawner: S,
         actor: A,
     ) -> Address<A::Message<'static>>
     where
-        <A as Actor>::OnMountFuture<
-            'static,
-            embassy_sync::channel::Receiver<
-                'static,
-                MUT,
-                <A as Actor>::Message<'static>,
-                QUEUE_SIZE,
-            >,
-        >: Send,
+        A::OnMountFuture<'static, Receiver<'static, MUT, A::Message<'static>, QUEUE_SIZE>>: Send,
     {
         let (address, future) = self.initialize(actor);
         let task = &self.task;

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -11,6 +11,9 @@ use {
     },
 };
 
+// Reexport mutex types
+pub use embassy_sync::blocking_mutex::raw::*;
+
 /// Trait that each actor must implement. An actor defines a message type
 /// that it acts on, and an implementation of `on_mount` which is invoked
 /// when the actor is started.

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -11,9 +11,6 @@ use {
     },
 };
 
-// Reexport mutex types
-pub use embassy_sync::blocking_mutex::raw::*;
-
 /// Trait that each actor must implement. An actor defines a message type
 /// that it acts on, and an implementation of `on_mount` which is invoked
 /// when the actor is started.

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -8,7 +8,6 @@
 pub(crate) mod fmt;
 
 mod actor;
-pub use embassy_sync;
 pub use {actor::*, ector_macros::*};
 
 #[cfg(all(feature = "std", feature = "test-util"))]

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -8,7 +8,7 @@
 pub(crate) mod fmt;
 
 mod actor;
-
+pub use embassy_sync;
 pub use {actor::*, ector_macros::*};
 
 #[cfg(all(feature = "std", feature = "test-util"))]
@@ -20,5 +20,25 @@ macro_rules! spawn_actor {
     ($spawner:ident, $name:ident, $ty:ty, $instance:expr) => {{
         static $name: ::ector::ActorContext<$ty> = ::ector::ActorContext::new();
         $name.mount($spawner, $instance)
+    }};
+
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty) => {{
+        static $name: ::ector::ActorContext<$ty, $mutex> = ::ector::ActorContext::new();
+        $name.mount_send($spawner, $instance)
+    }};
+
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:literal) => {{
+        static $name: ::ector::ActorContext<
+            $ty,
+            embassy_sync::blocking_mutex::raw::NoopRawMutex,
+            $queue_size,
+        > = ::ector::ActorContext::new();
+        $name.mount($spawner, $instance)
+    }};
+
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty, $queue_size:literal) => {{
+        static $name: ::ector::ActorContext<$ty, $mutex, $queue_size> =
+            ::ector::ActorContext::new();
+        $name.mount_send($spawner, $instance)
     }};
 }

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -10,6 +10,11 @@ pub(crate) mod fmt;
 mod actor;
 pub use {actor::*, ector_macros::*};
 
+// Reexport mutex types
+pub mod mutex {
+    pub use embassy_sync::blocking_mutex::raw::*;
+}
+
 #[cfg(all(feature = "std", feature = "test-util"))]
 pub mod testutil;
 
@@ -27,11 +32,8 @@ macro_rules! spawn_actor {
     }};
 
     ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:literal) => {{
-        static $name: ::ector::ActorContext<
-            $ty,
-            embassy_sync::blocking_mutex::raw::NoopRawMutex,
-            $queue_size,
-        > = ::ector::ActorContext::new();
+        static $name: ::ector::ActorContext<$ty, ::ector::mutex::NoopRawMutex, $queue_size> =
+            ::ector::ActorContext::new();
         $name.mount($spawner, $instance)
     }};
 


### PR DESCRIPTION
Added support for different types of mutexes, mainly to support [multiple priorities](https://github.com/embassy-rs/embassy/blob/master/examples/nrf52840/src/bin/multiprio.rs).

Defaults to `NoopRawMutex` so hopefully it should not be a breaking change.

The raw mutex from `embassy-sync` are reexported so the user can have the git version of  embassy-sync and use the raw mutex reexported by ector for ector and the git version for the rest of it's code.

Also extended the macro for different mutex or queue sizes.

There is a limitation though, it seems using `static` lifetimes on message doesn't compile.
I'm pretty sure it's caused by the `mount_send` `Send` trait bound but after trying to massage the lifetime I can't get it to compile. Feel free to suggest a fix to allow `static` lifetimes

Here is an example that doesn't work, it's the same as the `macro-usage` example that was added, but uses `&'static str` instead of `String`. 

```rs
use ector::{mutex::CriticalSectionRawMutex, *};
use embassy_time::{Duration, Timer};

#[embassy_executor::main]
async fn main(s: embassy_executor::Spawner) {
    let server_1 = spawn_actor!(s, SERVER_1, Server, Server);
    let server_2 = spawn_actor!(s, SERVER_2, Server, Server, CriticalSectionRawMutex);
    let server_3 = spawn_actor!(s, SERVER_3, Server, Server, 2);
    let server_4 = spawn_actor!(s, SERVER_4, Server, Server, CriticalSectionRawMutex, 2);

    let servers = [server_1, server_2, server_3, server_4];
    loop {
        for (i, server) in servers.iter().enumerate() {
            let r = server.request("Hello").await;
            println!("Server {} returned {}", i, r);
            Timer::after(Duration::from_secs(1)).await;
        }
    }
}

pub struct Server;

#[actor]
impl Actor for Server {
    type Message<'m> = Request<&'static str, &'static str, CriticalSectionRawMutex>;
    async fn on_mount<M>(
        &mut self,
        _: Address<Request<&'static str, &'static str, CriticalSectionRawMutex>>,
        mut inbox: M,
    ) where
        M: Inbox<Self::Message<'m>> + 'm,
    {
        println!("Server started!");

        loop {
            let motd = inbox.next().await;
            let m = motd.as_ref().clone();
            motd.reply(m).await;
        }
    }
}
```