### PR TITLE
feat: Added support for `Send` addresses

### DIFF
--- a/ector/examples/pingpong.rs
+++ b/ector/examples/pingpong.rs
@@ -8,7 +8,7 @@ use {
     embassy_time::{Duration, Ticker},
     futures::{
         future::{join, select, Either},
-        pin_mut,
+        pin_mut, StreamExt,
     },
 };
 
@@ -18,8 +18,8 @@ async fn main(_s: embassy_executor::Spawner) {
     static PINGER: ActorContext<Pinger> = ActorContext::new();
     static PONGER: ActorContext<Ponger> = ActorContext::new();
 
-    let pinger_addr = PINGER.address();
-    let ponger_addr = PONGER.address();
+    let pinger_addr = PINGER.dyn_address();
+    let ponger_addr = PONGER.dyn_address();
 
     let pinger = PINGER.mount(Pinger(ponger_addr));
     let ponger = PONGER.mount(Ponger(pinger_addr));
@@ -32,13 +32,13 @@ pub struct Ping;
 #[derive(Debug)]
 pub struct Pong;
 
-pub struct Pinger(Address<Ping>);
-pub struct Ponger(Address<Pong>);
+pub struct Pinger(DynamicAddress<Ping>);
+pub struct Ponger(DynamicAddress<Pong>);
 
 impl Actor for Pinger {
     type Message = Pong;
 
-    async fn on_mount<M>(&mut self, _: Address<Pong>, mut inbox: M) -> !
+    async fn on_mount<M>(&mut self, _: DynamicAddress<Pong>, mut inbox: M) -> !
     where
         M: Inbox<Self::Message>,
     {
@@ -68,7 +68,7 @@ impl Actor for Pinger {
 
 impl Actor for Ponger {
     type Message = Ping;
-    async fn on_mount<M>(&mut self, _: Address<Ping>, mut inbox: M) -> !
+    async fn on_mount<M>(&mut self, _: DynamicAddress<Ping>, mut inbox: M) -> !
     where
         M: Inbox<Self::Message>,
     {

--- a/ector/examples/request.rs
+++ b/ector/examples/request.rs
@@ -9,7 +9,7 @@ use {
     futures::future::join,
 };
 
-async fn test(addr: Address<Request<&'static str, &'static str>>) {
+async fn test(addr: DynamicAddress<Request<&'static str, &'static str>>) {
     let r = addr.request("Hello").await;
     println!("Server returned {}", r);
     Timer::after(Duration::from_secs(1)).await;
@@ -20,7 +20,7 @@ async fn main(_s: embassy_executor::Spawner) {
     // Example of request response
     static SERVER: ActorContext<Server> = ActorContext::new();
 
-    let address = SERVER.address();
+    let address = SERVER.dyn_address();
     let server = SERVER.mount(Server);
     let test = test(address);
     join(server, test).await;
@@ -33,7 +33,7 @@ impl Actor for Server {
 
     async fn on_mount<M>(
         &mut self,
-        _: Address<Request<&'static str, &'static str>>,
+        _: DynamicAddress<Request<&'static str, &'static str>>,
         mut inbox: M,
     ) -> !
     where

--- a/ector/examples/send.rs
+++ b/ector/examples/send.rs
@@ -1,0 +1,46 @@
+#![macro_use]
+#![feature(type_alias_impl_trait)]
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+use ector::mutex::CriticalSectionRawMutex;
+
+use {
+    ector::*,
+    embassy_time::{Duration, Timer},
+};
+
+#[embassy_executor::task]
+async fn send_task(address: Address<Request<String, String>, CriticalSectionRawMutex, 1>) {
+    loop {
+        let r = address.request("Hello".to_string()).await;
+        println!("Server returned {}", r);
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(s: embassy_executor::Spawner) {
+    let send_spawner = s.make_send();
+    //  CriticalSectionRawMutex makes the address `Send`
+    let server_addr = actor!(s, server_0, Server, Server, CriticalSectionRawMutex);
+    send_spawner.spawn(send_task(server_addr)).unwrap();
+}
+
+pub struct Server;
+
+impl Actor for Server {
+    type Message = Request<String, String>;
+    async fn on_mount<M>(&mut self, _: DynamicAddress<Request<String, String>>, mut inbox: M) -> !
+    where
+        M: Inbox<Self::Message>,
+    {
+        println!("Server started!");
+
+        loop {
+            let motd = inbox.next().await;
+            let m = motd.as_ref().clone();
+            motd.reply(m).await;
+        }
+    }
+}

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -1,4 +1,4 @@
-use embassy_sync::blocking_mutex::raw::RawMutex;
+use embassy_sync::{blocking_mutex::raw::RawMutex, channel::Sender};
 
 use static_cell::StaticCell;
 
@@ -20,7 +20,7 @@ pub trait Actor: Sized {
 
     /// Called when an actor is mounted (activated). The actor will be provided with the
     /// address to itself, and an inbox used to receive incoming messages.
-    async fn on_mount<M>(&mut self, _: Address<Self::Message>, _: M) -> !
+    async fn on_mount<M>(&mut self, _: DynamicAddress<Self::Message>, _: M) -> !
     where
         M: Inbox<Self::Message>;
 }
@@ -44,76 +44,111 @@ where
     }
 }
 
-/// A handle to another actor for dispatching messages.
+/// A trait send message to another actor.
 ///
-/// Individual actor implementations may augment the `Address` object
+/// Individual actor implementations may augment the `ActorAddress` object
 /// when appropriate bounds are met to provide method-like invocations.
-pub struct Address<M>
-where
-    M: 'static,
-{
-    state: DynamicSender<'static, M>,
-}
-
-impl<M> Address<M> {
-    fn new(state: DynamicSender<'static, M>) -> Self {
-        Self { state }
-    }
-}
-
-impl<M> Address<M> {
+pub trait ActorAddress<M> {
     /// Attempt to send a message to the actor behind this address. If an error
     /// occurs when enqueueing the message on the destination actor, the message is returned.
-    pub fn try_notify(&self, message: M) -> Result<(), M> {
-        self.state.try_send(message).map_err(|e| match e {
+    fn try_notify(&self, message: M) -> Result<(), M>;
+
+    /// Attempt to deliver a message until successful.
+    async fn notify(&self, message: M);
+}
+
+pub trait ActorRequest<M, R> {
+    /// Attempts to send a message and wait for the response
+    async fn request(&self, message: M) -> R;
+}
+
+impl<'a, M> ActorAddress<M> for DynamicSender<'a, M> {
+    fn try_notify(&self, message: M) -> Result<(), M> {
+        self.try_send(message).map_err(|e| match e {
             TrySendError::Full(m) => m,
         })
     }
 
-    // Attempt to deliver a message until successful.
-    pub async fn notify(&self, message: M) {
-        self.state.send(message).await
+    async fn notify(&self, message: M) {
+        self.send(message).await
     }
 }
 
-impl<M, R, MUT> Address<Request<M, R, MUT>>
-where
-    MUT: RawMutex,
-{
-    pub async fn request(&self, message: M) -> R {
-        let reply_to: Channel<MUT, R, 1> = Channel::new();
+impl<'a, M, R> ActorRequest<M, R> for DynamicSender<'a, Request<M, R>> {
+    async fn request(&self, message: M) -> R {
+        let channel: Channel<NoopRawMutex, R, 1> = Channel::new();
+        let sender: DynamicSender<'_, R> = channel.sender().into();
+
         // We guarantee that channel lives until we've been notified on it, at which
         // point its out of reach for the replier.
-        let message = Request::new(message, unsafe { core::mem::transmute(&reply_to) });
+        let reply_to = unsafe { core::mem::transmute(&sender) };
+        let message = Request::new(message, reply_to);
         self.notify(message).await;
-        reply_to.recv().await
+        channel.recv().await
     }
 }
 
-impl<M> Clone for Address<M> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
-}
-
-type ReplyTo<T, MUT> = Channel<MUT, T, 1>;
-
-pub struct Request<M, R, MUT = NoopRawMutex>
-where
-    R: 'static,
-    MUT: RawMutex + 'static,
-{
-    message: Option<M>,
-    reply_to: &'static ReplyTo<R, MUT>,
-}
-
-impl<M, R, MUT> Request<M, R, MUT>
+impl<'a, M, MUT, const N: usize> ActorAddress<M> for Sender<'a, MUT, M, N>
 where
     MUT: RawMutex,
 {
-    fn new(message: M, reply_to: &'static ReplyTo<R, MUT>) -> Self {
+    fn try_notify(&self, message: M) -> Result<(), M> {
+        self.try_send(message).map_err(|e| match e {
+            TrySendError::Full(m) => m,
+        })
+    }
+
+    async fn notify(&self, message: M) {
+        self.send(message).await
+    }
+}
+
+impl<'a, M, R, MUT, const N: usize> ActorRequest<M, R> for Sender<'a, MUT, Request<M, R>, N>
+where
+    M: 'static,
+    MUT: RawMutex + 'static,
+{
+    async fn request(&self, message: M) -> R {
+        let channel: Channel<MUT, R, 1> = Channel::new();
+        let sender: DynamicSender<'_, R> = channel.sender().into();
+
+        // We guarantee that channel lives until we've been notified on it, at which
+        // point its out of reach for the replier.
+        let reply_to = unsafe { core::mem::transmute(&sender) };
+        let message = Request::new(message, reply_to);
+        self.notify(message).await;
+        channel.recv().await
+    }
+}
+
+/// A handle to another actor for dispatching messages.
+///
+/// Individual actor implementations may augment the `Address` object
+/// when appropriate bounds are met to provide method-like invocations.
+pub type DynamicAddress<M> = DynamicSender<'static, M>;
+
+/// A handle to another actor for dispatching messages.
+///
+/// Individual actor implementations may augment the `Address` object
+/// when appropriate bounds are met to provide method-like invocations.
+pub type Address<M, MUT = NoopRawMutex, const N: usize = 1> = Sender<'static, MUT, M, N>;
+
+pub struct Request<M, R>
+where
+    R: 'static,
+{
+    message: Option<M>,
+    reply_to: &'static DynamicSender<'static, R>,
+}
+
+/// Safety: Only the [Address] or [DynamicAddress] build requests, meaning that they will use the approriate mutex
+/// even if it uses [DynamicSender] internally
+/// For [DynamicAddress] a [NoopRawMutex] since it's already not send
+/// For [Address], the matching mutex is used
+unsafe impl<M, R> Send for Request<M, R> {}
+
+impl<M, R> Request<M, R> {
+    fn new(message: M, reply_to: &'static DynamicSender<'static, R>) -> Self {
         Self {
             message: Some(message),
             reply_to,
@@ -130,19 +165,13 @@ where
     }
 }
 
-impl<M, R, MUT> AsRef<M> for Request<M, R, MUT>
-where
-    MUT: RawMutex,
-{
+impl<M, R> AsRef<M> for Request<M, R> {
     fn as_ref(&self) -> &M {
         self.message.as_ref().unwrap()
     }
 }
 
-impl<M, R, MUT> AsMut<M> for Request<M, R, MUT>
-where
-    MUT: RawMutex,
-{
+impl<M, R> AsMut<M> for Request<M, R> {
     fn as_mut(&mut self) -> &mut M {
         self.message.as_mut().unwrap()
     }
@@ -191,12 +220,16 @@ where
     /// Mount the underlying actor and initialize the channel.
     pub async fn mount(&'static self, actor: A) -> ! {
         let actor = self.actor.init(actor);
-        let address = Address::new(self.channel.sender().into());
+        let address = self.channel.sender().into();
         let receiver = self.channel.receiver();
         actor.on_mount(address, receiver).await
     }
 
-    pub fn address(&'static self) -> Address<A::Message> {
-        Address::new(self.channel.sender().into())
+    pub fn dyn_address(&'static self) -> DynamicAddress<A::Message> {
+        self.channel.sender().into()
+    }
+
+    pub fn address(&'static self) -> Address<A::Message, MUT, QUEUE_SIZE> {
+        self.channel.sender()
     }
 }

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -127,11 +127,17 @@ where
 /// when appropriate bounds are met to provide method-like invocations.
 pub type DynamicAddress<M> = DynamicSender<'static, M>;
 
+/// Type alias over a [DynamicAddress] using a [Request] as message
+pub type DynamicRequestAddress<M, R> = DynamicSender<'static, Request<M, R>>;
+
 /// A handle to another actor for dispatching messages.
 ///
 /// Individual actor implementations may augment the `Address` object
 /// when appropriate bounds are met to provide method-like invocations.
 pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
+
+/// Type alias over a [Address] using a [Request] as message
+pub type RequestAddress<M, R, MUT, const N: usize = 1> = Sender<'static, MUT, Request<M, R>, N>;
 
 pub struct Request<M, R>
 where

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -131,7 +131,7 @@ pub type DynamicAddress<M> = DynamicSender<'static, M>;
 ///
 /// Individual actor implementations may augment the `Address` object
 /// when appropriate bounds are met to provide method-like invocations.
-pub type Address<M, MUT = NoopRawMutex, const N: usize = 1> = Sender<'static, MUT, M, N>;
+pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
 
 pub struct Request<M, R>
 where

--- a/ector/src/testutils.rs
+++ b/ector/src/testutils.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Actor, Address, Inbox},
+    crate::{Actor, DynamicAddress, Inbox},
     atomic_polyfill::{AtomicBool, Ordering},
     core::{cell::RefCell, future::Future, pin::Pin},
     embassy_executor::{raw, Spawner},
@@ -60,7 +60,7 @@ impl DummyActor {
 impl Actor for DummyActor {
     type Message = TestMessage;
 
-    async fn on_mount<M>(&mut self, _: Address<TestMessage>, mut inbox: M) -> !
+    async fn on_mount<M>(&mut self, _: DynamicAddress<TestMessage>, mut inbox: M) -> !
     where
         M: Inbox<TestMessage>,
     {
@@ -84,7 +84,7 @@ impl TestHandler {
 impl Actor for TestHandler {
     type Message = TestMessage;
 
-    async fn on_mount<M>(&mut self, _: Address<TestMessage>, mut inbox: M) -> !
+    async fn on_mount<M>(&mut self, _: DynamicAddress<TestMessage>, mut inbox: M) -> !
     where
         M: Inbox<TestMessage>,
     {

--- a/ector/tests/integration_tests.rs
+++ b/ector/tests/integration_tests.rs
@@ -30,7 +30,7 @@ mod tests {
         impl Actor for MyActor {
             type Message = Add;
 
-            async fn on_mount<'m, M>(&'m mut self, _: Address<Add>, mut inbox: M) -> !
+            async fn on_mount<'m, M>(&'m mut self, _: DynamicAddress<Add>, mut inbox: M) -> !
             where
                 M: Inbox<Add>,
             {
@@ -45,7 +45,7 @@ mod tests {
         async fn main(_s: Spawner) {
             static ACTOR: ActorContext<MyActor> = ActorContext::new();
 
-            let a_addr = ACTOR.address();
+            let a_addr = ACTOR.dyn_address();
             let _ = a_addr.try_notify(Add(10));
             ACTOR
                 .mount(MyActor {

--- a/ector/tests/notifications.rs
+++ b/ector/tests/notifications.rs
@@ -12,7 +12,7 @@ use ector::{
 #[test]
 fn test_sync_notifications() {
     static ACTOR: ActorContext<DummyActor, mutex::NoopRawMutex, 1> = ActorContext::new();
-    let address = ACTOR.address();
+    let address = ACTOR.dyn_address();
     let mut actor_fut = ACTOR.mount(DummyActor::new());
 
     let result_1 = address.try_notify(TestMessage(0));


### PR DESCRIPTION
I saw that you are preparing for a release, so I'll just add this PR as WIP while I finish it up if you want to add it in the next release.

Currently, the `Address` where not send because they used `DynamicSender` internally. Instead, the Address logic was moved to a trait `ActorAddress` and then the `DynamicSender` and `Sender` implements the trait.

A type reexport was added to make it feel similar, so we have `DynamicAddress` and `Address` which are simply reexports for `DynamicSender` and `Sender` with static lifetimes.

Also, this removes the Mutex requirement in `Request` that was added previously. 

~~I'm still testing it out on my codebase, in the meantime, feel free to comment on the changes~~