### PR TITLE
Feat/request cancel support

### DIFF
--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -28,8 +28,8 @@ static_cell = "1.0.0"
 
 
 [dev-dependencies]
+embassy-time = { version = "0.1.1", default-features = false, features = ["std", "nightly"] }
 embassy-executor = { version = "0.3.0", default-features = false, features = ["integrated-timers", "nightly", "arch-std", "executor-thread"]}
-embassy-time = { version = "0.1.0", default-features = false, features = ["std", "nightly"] }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 critical-section = { version = "1.1", features = ["std"] }
 ector = { path = ".", features = ["std", "log", "time", "test-utils"] }

--- a/ector/examples/cancelled.rs
+++ b/ector/examples/cancelled.rs
@@ -1,0 +1,63 @@
+#![macro_use]
+#![feature(type_alias_impl_trait)]
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+use embassy_time::with_timeout;
+
+use {
+    ector::*,
+    embassy_time::{Duration, Timer},
+    futures::future::join,
+};
+
+async fn test(mut addr: RequestManager<DynamicAddress<Request<(), u32>>, (), u32>) {
+    let r = addr.request(()).await;
+    assert_eq!(r, 1);
+    println!("Server returned {}", r);
+    Timer::after(Duration::from_secs(1)).await;
+
+    match with_timeout(Duration::from_micros(1), addr.request(())).await {
+        Ok(_) => panic!("Server should timeout"),
+        Err(_) => println!(
+            "Server timedout as expected, counter should be increased, but message skipped"
+        ),
+    }
+
+    let r = addr.request(()).await;
+    assert_eq!(r, 3);
+    println!("Server returned {}", r);
+}
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) {
+    // Example of request response
+    static SERVER: ActorContext<Server> = ActorContext::new();
+
+    let address = req!(SERVER.dyn_address(), u32);
+    let server = SERVER.mount(Server);
+    let test = test(address);
+    join(server, test).await;
+}
+
+pub struct Server;
+
+impl Actor for Server {
+    type Message = Request<(), u32>;
+
+    async fn on_mount<M>(&mut self, _: DynamicAddress<Request<(), u32>>, mut inbox: M) -> !
+    where
+        M: Inbox<Self::Message>,
+    {
+        println!("Server started!");
+        let mut counter = 0;
+
+        loop {
+            let req = inbox.next().await;
+            counter += 1;
+            // Simulate long calculation before cancel
+            Timer::after(Duration::from_secs(1)).await;
+            req.reply(counter).await;
+        }
+    }
+}

--- a/ector/examples/cancelled.rs
+++ b/ector/examples/cancelled.rs
@@ -11,7 +11,7 @@ use {
     futures::future::join,
 };
 
-async fn test(mut addr: RequestManager<DynamicAddress<Request<(), u32>>, (), u32>) {
+async fn test(mut addr: DynamicRequestAddress<(), u32>) {
     let r = addr.request(()).await;
     assert_eq!(r, 1);
     println!("Server returned {}", r);

--- a/ector/examples/cancelled.rs
+++ b/ector/examples/cancelled.rs
@@ -34,7 +34,7 @@ async fn main(_s: embassy_executor::Spawner) {
     // Example of request response
     static SERVER: ActorContext<Server> = ActorContext::new();
 
-    let address = req!(SERVER.dyn_address(), u32);
+    let address = request!(SERVER.dyn_address(), u32);
     let server = SERVER.mount(Server);
     let test = test(address);
     join(server, test).await;

--- a/ector/examples/macro-usage.rs
+++ b/ector/examples/macro-usage.rs
@@ -12,6 +12,7 @@ use {
 async fn main(s: embassy_executor::Spawner) {
     let server_0_addr: DynamicAddress<Request<String, String>> =
         actor!(s, server_0, Server, Server).into();
+
     let server_1_addr = actor!(s, server_1, Server, Server, NoopRawMutex).into();
     let server_2_addr = actor!(s, server_2, Server, Server, 2).into();
     let server_3_addr = actor!(s, server_3, Server, Server, NoopRawMutex, 2).into();
@@ -22,8 +23,16 @@ async fn main(s: embassy_executor::Spawner) {
     let server_5_addr =
         spawn_context!(SERVER_5, s, server_5, Server, Server, NoopRawMutex, 2).into();
 
+    // Adding support for request
+    let server_0_addr = req!(server_0_addr, String);
+    let server_1_addr = req!(server_1_addr, String);
+    let server_2_addr = req!(server_2_addr, String);
+    let server_3_addr = req!(server_3_addr, String);
+    let server_4_addr = req!(server_4_addr, String);
+    let server_5_addr = req!(server_5_addr, String);
+
     // Array of DynamicAddress
-    let servers = [
+    let mut servers = [
         server_0_addr,
         server_1_addr,
         server_2_addr,
@@ -32,7 +41,7 @@ async fn main(s: embassy_executor::Spawner) {
         server_5_addr,
     ];
     loop {
-        for (i, server) in servers.iter().enumerate() {
+        for (i, server) in servers.iter_mut().enumerate() {
             let r = server.request("Hello".to_string()).await;
             println!("Server {} returned {}", i, r);
             Timer::after(Duration::from_secs(1)).await;

--- a/ector/examples/macro-usage.rs
+++ b/ector/examples/macro-usage.rs
@@ -24,12 +24,12 @@ async fn main(s: embassy_executor::Spawner) {
         spawn_context!(SERVER_5, s, server_5, Server, Server, NoopRawMutex, 2).into();
 
     // Adding support for request
-    let server_0_addr = req!(server_0_addr, String);
-    let server_1_addr = req!(server_1_addr, String);
-    let server_2_addr = req!(server_2_addr, String);
-    let server_3_addr = req!(server_3_addr, String);
-    let server_4_addr = req!(server_4_addr, String);
-    let server_5_addr = req!(server_5_addr, String);
+    let server_0_addr = request!(server_0_addr, String);
+    let server_1_addr = request!(server_1_addr, String);
+    let server_2_addr = request!(server_2_addr, String);
+    let server_3_addr = request!(server_3_addr, String);
+    let server_4_addr = request!(server_4_addr, String);
+    let server_5_addr = request!(server_5_addr, String);
 
     // Array of DynamicAddress
     let mut servers = [

--- a/ector/examples/request.rs
+++ b/ector/examples/request.rs
@@ -9,7 +9,13 @@ use {
     futures::future::join,
 };
 
-async fn test(addr: DynamicAddress<Request<&'static str, &'static str>>) {
+async fn test(
+    mut addr: RequestManager<
+        DynamicAddress<Request<&'static str, &'static str>>,
+        &'static str,
+        &'static str,
+    >,
+) {
     let r = addr.request("Hello").await;
     println!("Server returned {}", r);
     Timer::after(Duration::from_secs(1)).await;
@@ -20,7 +26,7 @@ async fn main(_s: embassy_executor::Spawner) {
     // Example of request response
     static SERVER: ActorContext<Server> = ActorContext::new();
 
-    let address = SERVER.dyn_address();
+    let address = req!(SERVER.dyn_address(), &'static str);
     let server = SERVER.mount(Server);
     let test = test(address);
     join(server, test).await;

--- a/ector/examples/request.rs
+++ b/ector/examples/request.rs
@@ -9,13 +9,7 @@ use {
     futures::future::join,
 };
 
-async fn test(
-    mut addr: RequestManager<
-        DynamicAddress<Request<&'static str, &'static str>>,
-        &'static str,
-        &'static str,
-    >,
-) {
+async fn test(mut addr: DynamicRequestAddress<&'static str, &'static str>) {
     let r = addr.request("Hello").await;
     println!("Server returned {}", r);
     Timer::after(Duration::from_secs(1)).await;

--- a/ector/examples/request.rs
+++ b/ector/examples/request.rs
@@ -26,7 +26,7 @@ async fn main(_s: embassy_executor::Spawner) {
     // Example of request response
     static SERVER: ActorContext<Server> = ActorContext::new();
 
-    let address = req!(SERVER.dyn_address(), &'static str);
+    let address = request!(SERVER.dyn_address(), &'static str);
     let server = SERVER.mount(Server);
     let test = test(address);
     join(server, test).await;

--- a/ector/examples/send.rs
+++ b/ector/examples/send.rs
@@ -31,7 +31,7 @@ async fn main(s: embassy_executor::Spawner) {
     let send_spawner = s.make_send();
     //  CriticalSectionRawMutex makes the address `Send`
     let server_addr = actor!(s, server_0, Server, Server, CriticalSectionRawMutex);
-    let request_manager = req!(server_addr, String, CriticalSectionRawMutex);
+    let request_manager = request!(server_addr, String, CriticalSectionRawMutex);
     send_spawner.spawn(send_task(request_manager)).unwrap();
 }
 

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -161,7 +161,7 @@ where
 /// when appropriate bounds are met to provide method-like invocations.
 pub type DynamicAddress<M> = DynamicSender<'static, M>;
 
-/// Type alias over a [DynamicAddress] using a [Request] as message
+/// Type alias over a [RequestManager] using a [DynamicAddress] using a [Request] as message
 pub type DynamicRequestAddress<M, R> = RequestManager<DynamicSender<'static, Request<M, R>>, M, R>;
 
 /// A handle to another actor for dispatching messages.
@@ -170,7 +170,7 @@ pub type DynamicRequestAddress<M, R> = RequestManager<DynamicSender<'static, Req
 /// when appropriate bounds are met to provide method-like invocations.
 pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
 
-/// Type alias over a [Address] using a [Request] as message
+/// Type alias over a [RequestManager] using an [Address] using a [Request] as message
 pub type RequestAddress<M, R, MUT, const N: usize = 1> =
     RequestManager<Sender<'static, Request<M, R>, MUT, N>, M, R, MUT>;
 

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -98,7 +98,6 @@ pub trait ActorRequest<M, R> {
 
 pub struct RequestManager<A, M, R, MUT = NoopRawMutex>
 where
-    A: ActorAddress<Request<M, R>>,
     MUT: RawMutex + 'static,
     M: 'static,
     R: 'static,
@@ -149,7 +148,7 @@ where
         let message = Request::new(message, self.reply_from.clone().into());
         self.addr.notify(message).await;
         self.cancelled += 1;
-        let reply = self.reply_to.recv().await;
+        let reply = self.reply_to.receive().await;
         self.cancelled -= 1;
 
         reply

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -147,8 +147,8 @@ where
         self.handle_missed().await;
 
         let message = Request::new(message, self.reply_from.clone().into());
-        self.cancelled += 1;
         self.addr.notify(message).await;
+        self.cancelled += 1;
         let reply = self.reply_to.recv().await;
         self.cancelled -= 1;
 

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -116,7 +116,7 @@ where
 {
     /// Creates a new instance of the request manager.
     /// The channel must be provided by the user and only used by this manager
-    pub fn new(addr: A, channel: &'static mut Channel<MUT, R, 1>) -> Self
+    pub fn new(addr: A, channel: &'static Channel<MUT, R, 1>) -> Self
     where
         MUT: RawMutex,
     {
@@ -145,7 +145,7 @@ where
     async fn request(&mut self, message: M) -> R {
         self.handle_missed().await;
 
-        let message = Request::new(message, self.reply_from.clone().into());
+        let message = Request::new(message, self.reply_from.into());
         self.addr.notify(message).await;
         self.cancelled += 1;
         let reply = self.reply_to.receive().await;

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -172,7 +172,7 @@ pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
 
 /// Type alias over a [RequestManager] using an [Address] using a [Request] as message
 pub type RequestAddress<M, R, MUT, const N: usize = 1> =
-    RequestManager<Sender<'static, Request<M, R>, MUT, N>, M, R, MUT>;
+    RequestManager<Sender<'static, MUT, Request<M, R>, N>, M, R, MUT>;
 
 pub struct Request<M, R>
 where

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -144,8 +144,9 @@ where
     MUT: RawMutex,
 {
     async fn request(&mut self, message: M) -> R {
-        let message = Request::new(message, self.reply_from.clone().into());
+        self.handle_missed().await;
 
+        let message = Request::new(message, self.reply_from.clone().into());
         self.cancelled += 1;
         self.addr.notify(message).await;
         let reply = self.reply_to.recv().await;

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -162,7 +162,7 @@ where
 pub type DynamicAddress<M> = DynamicSender<'static, M>;
 
 /// Type alias over a [DynamicAddress] using a [Request] as message
-pub type DynamicRequestAddress<M, R> = DynamicSender<'static, Request<M, R>>;
+pub type DynamicRequestAddress<M, R> = RequestManager<DynamicSender<'static, Request<M, R>>, M, R>;
 
 /// A handle to another actor for dispatching messages.
 ///
@@ -171,7 +171,8 @@ pub type DynamicRequestAddress<M, R> = DynamicSender<'static, Request<M, R>>;
 pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
 
 /// Type alias over a [Address] using a [Request] as message
-pub type RequestAddress<M, R, MUT, const N: usize = 1> = Sender<'static, MUT, Request<M, R>, N>;
+pub type RequestAddress<M, R, MUT, const N: usize = 1> =
+    RequestManager<Sender<'static, Request<M, R>, MUT, N>, M, R, MUT>;
 
 pub struct Request<M, R>
 where

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -114,7 +114,7 @@ macro_rules! spawn_context {
 /// Makes an address support a request
 #[macro_export]
 macro_rules! req {
-    ($address:ident, $response:ty) => {{
+    ($address:expr, $response:ty) => {{
         static REQUEST_CHANNEL: ::ector::stat::StaticCell<
             ::ector::sync::Channel<::ector::mutex::NoopRawMutex, $response, 1>,
         > = ::ector::stat::StaticCell::new();
@@ -122,7 +122,7 @@ macro_rules! req {
         ::ector::RequestManager::new($address, channel)
     }};
 
-    ($address:ident, $response:ty, $mutex:ty) => {{
+    ($address:expr, $response:ty, $mutex:ty) => {{
         static REQUEST_CHANNEL: ::ector::stat::StaticCell<
             ::ector::sync::Channel<$mutex, $response, 1>,
         > = ::ector::stat::StaticCell::new();

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -111,9 +111,9 @@ macro_rules! spawn_context {
     }};
 }
 
-/// Makes an address support a request
+/// Makes an address support the [Request] trait
 #[macro_export]
-macro_rules! req {
+macro_rules! request {
     ($address:expr, $response:ty) => {{
         static REQUEST_CHANNEL: ::ector::stat::StaticCell<
             ::ector::sync::Channel<::ector::mutex::NoopRawMutex, $response, 1>,


### PR DESCRIPTION
Fixes #11

Note that the previous implementations was removed, we could keep them and add the cancel limitation in the comments.

It's starting to get a bit unwieldy for the typing when things need to specify the types and generics are not supported (ex: embassy tasks).

`ActoRequest` now uses a mutable reference to avoid doing two request from the same `ActorRequest` and joining them since  the first reply could be associated with the second request for example.
