### PR TITLE
feat: Added drop bomb to panic in case of request cancellation

### DIFF
--- a/ector/examples/cancel_panic.rs
+++ b/ector/examples/cancel_panic.rs
@@ -1,0 +1,52 @@
+//! Example where cancellation will cause a panic
+
+#![macro_use]
+#![feature(type_alias_impl_trait)]
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
+
+use {
+    ector::*,
+    embassy_time::{Duration, Timer},
+    futures::future::{join, select},
+};
+
+async fn test(addr: DynamicAddress<Request<&'static str, &'static str>>) {
+    let req = core::pin::pin!(addr.request("Hello"));
+    let timeout = Timer::after(Duration::from_secs(1));
+    select(req, timeout).await;
+    println!("Timeout");
+}
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) {
+    // Example of request response
+    static SERVER: ActorContext<Server> = ActorContext::new();
+
+    let address = SERVER.dyn_address();
+    let server = SERVER.mount(Server);
+    let test = test(address);
+    join(server, test).await;
+}
+
+pub struct Server;
+
+impl Actor for Server {
+    type Message = Request<&'static str, &'static str>;
+
+    async fn on_mount<M>(
+        &mut self,
+        _: DynamicAddress<Request<&'static str, &'static str>>,
+        mut inbox: M,
+    ) -> !
+    where
+        M: Inbox<Self::Message>,
+    {
+        println!("Server started!");
+
+        loop {
+            // We don't reply, since we cancel
+            inbox.next().await;
+        }
+    }
+}

--- a/ector/src/actor.rs
+++ b/ector/src/actor.rs
@@ -138,6 +138,9 @@ where
 pub type DynamicAddress<M> = DynamicSender<'static, M>;
 
 /// Type alias over a [DynamicAddress] using a [Request] as message
+///
+/// Safety: You should not cancel a request, it will cause the requesting thread to panic,
+/// and cause UB if the Actor is still alive after the panic (i.e. in a different thread)
 pub type DynamicRequestAddress<M, R> = DynamicSender<'static, Request<M, R>>;
 
 /// A handle to another actor for dispatching messages.
@@ -147,6 +150,9 @@ pub type DynamicRequestAddress<M, R> = DynamicSender<'static, Request<M, R>>;
 pub type Address<M, MUT, const N: usize = 1> = Sender<'static, MUT, M, N>;
 
 /// Type alias over a [Address] using a [Request] as message
+///
+/// Safety: You should not cancel a request, it will cause the requesting thread to panic,
+/// and cause UB if the Actor is still alive after the panic (i.e. in a different thread)
 pub type RequestAddress<M, R, MUT, const N: usize = 1> = Sender<'static, MUT, Request<M, R>, N>;
 
 pub struct Request<M, R>

--- a/ector/src/drop.rs
+++ b/ector/src/drop.rs
@@ -1,0 +1,25 @@
+//! Original reference https://github.com/embassy-rs/embassy/blob/e1ed492577d2151b4cc8ef995536dd045d2db087/embassy-hal-internal/src/drop.rs#L32
+
+/// Panics if it is improperly disposed of.
+///
+/// This is to forbid cancelling a future/request.
+///
+/// To properly dispose, call the [defuse](Self::defuse) method before this object is dropped.
+#[must_use = "to delay the drop bomb invokation to the end of the scope"]
+pub struct DropBomb(());
+impl DropBomb {
+    pub fn new() -> Self {
+        Self(())
+    }
+
+    /// Defuses the bomb, rendering it safe to drop.
+    pub fn defuse(self) {
+        core::mem::forget(self)
+    }
+}
+
+impl Drop for DropBomb {
+    fn drop(&mut self) {
+        panic!("Dropped before the request completed. You  cannot cancel an ongoing request")
+    }
+}

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -8,6 +8,7 @@
 pub(crate) mod fmt;
 
 mod actor;
+mod drop;
 pub use {actor::*, ector_macros::*};
 
 // Reexport mutex types


### PR DESCRIPTION
Similar to what embassy does, we just panic if an ongoing request is dropped, way simpler than previous attempt and keeping the same api.

Also, would fix #11.

I think it's not sound if we share the actor in multiple threads (since it can be send). Only the request thread will panic, the actor could use  the feed memory and cause UB. But since it's for embedded I feel like it's fine for now and it keeps it simple.