### PR TITLE
Add support for Rust stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,12 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly-2023-11-01
+
     steps:
       - uses: actions/checkout@v3
 

--- a/macros/build.rs
+++ b/macros/build.rs
@@ -1,0 +1,15 @@
+use std::{env, ffi::OsString, process::Command};
+
+fn main() {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+
+    let output = Command::new(rustc)
+        .arg("--version")
+        .output()
+        .expect("failed to run `rustc --version`");
+
+    if String::from_utf8_lossy(&output.stdout).contains("nightly") {
+        println!("cargo:rustc-cfg=nightly");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(proc_macro_diagnostic)]
+#![cfg_attr(nightly, feature(proc_macro_diagnostic))]
 
 extern crate proc_macro;
 mod actor;


### PR DESCRIPTION
It looks like https://github.com/drogue-iot/ector/commit/aa15f8eddb4a9caa3a19b11791307ec16f311787 removed most of the nightly dependencies, but this `feature` in ector-macros is still blocking support for stable.

Would enabling this feature with this `cfg(nightly)` through `build.rs` be an acceptable mechanism for supporting ector on stable Rust, while maintaining support for this nightly feature?