### PR TITLE
Change queue_size argument type to expr

### DIFF
--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -36,7 +36,7 @@ macro_rules! actor {
         ::ector::actor!($spawner, $name, $ty, $instance, $mutex, 1)
     }};
 
-    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:literal) => {{
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:expr) => {{
         ::ector::actor!(
             $spawner,
             $name,
@@ -47,7 +47,7 @@ macro_rules! actor {
         )
     }};
 
-    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty, $queue_size:literal) => {{
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty, $queue_size:expr) => {{
         static CONTEXT: ::ector::ActorContext<$ty, $mutex, $queue_size> =
             ::ector::ActorContext::new();
         ::ector::spawn_context!(
@@ -81,7 +81,7 @@ macro_rules! spawn_context {
         ::ector::spawn_context!($context, $spawner, $name, $ty, $instance, $mutex, 1)
     }};
 
-    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:literal) => {{
+    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:expr) => {{
         ::ector::spawn_context!(
             $context,
             $spawner,
@@ -93,7 +93,7 @@ macro_rules! spawn_context {
         )
     }};
 
-    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty, $queue_size:literal) => {{
+    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty, $queue_size:expr) => {{
         #[embassy_executor::task]
         async fn $name(a: &'static ::ector::ActorContext<$ty, $mutex, $queue_size>, instance: $ty) {
             a.mount(instance).await


### PR DESCRIPTION
As constants are evaluated after macros have been expanded, the current implementation of the `actor!` and `spawn_context!` macros do not allow a constant to be passed to the `queue_size` argument. This means that actors can only be instanced using anonymous numbers.

This PR changes the type of the `queue_size` argument to `expr`, which means constants can also be used.