### PR TITLE
Update to embassy-executor 0.9

### DIFF
--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "ector"
-version = "0.7.0"
+version = "0.8.0"
 description = "Ector is an open source async, no-alloc actor framework for embedded devices."
 documentation = "https://docs.rs/ector"
 readme = "../README.md"
@@ -15,9 +15,9 @@ exclude = [".github"]
 doctest = false
 
 [dependencies]
-embassy-executor = { version = "0.7", default-features = false }
+embassy-executor = { version = "0.9", default-features = false }
 embassy-sync = { version = "0.7", default-features = false }
-portable-atomic = { version = "1.3", default-features = false }
+portable-atomic = { version = "1.6", default-features = false }
 
 log = { version = "0.4", optional = true }
 defmt = { version = "1.0.1", optional = true }
@@ -28,14 +28,14 @@ static_cell = "2.1"
 
 
 [dev-dependencies]
-embassy-executor = { version = "0.7", default-features = false, features = [
+embassy-executor = { version = "0.9", default-features = false, features = [
     "arch-std",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4", default-features = false, features = [
+embassy-time = { version = "0.5", default-features = false, features = [
     "std",
 ] }
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 futures = { version = "0.3.31", default-features = false, features = [
     "executor",
 ] }

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -152,7 +152,8 @@ macro_rules! spawn_context {
         }
 
         let address = $context.address();
-        $spawner.spawn($name(&$context, $instance)).unwrap();
+        let task = $name(&$context, $instance).unwrap();
+        $spawner.spawn(task);
         address
     }};
 }


### PR DESCRIPTION
Upgrade edition to 2024 (like in Embasssy), upgrade some minor deps too. This changes way the unwrap() is used around Spawner.

portable-atomic in version 1.11 conflicts with rtt-target. Upgrading to 1.6 only.


This builds and my app builds with it. I haven't done in-hardware tests. Cargo test doesn't build though and I can't figure out why. Probably log feature instead of defmt makes the difference. Help?