### PR TITLE
chore: bump deps

### DIFF
--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "ector"
-version = "0.7.0"
+version = "0.9.0"
 description = "Ector is an open source async, no-alloc actor framework for embedded devices."
 documentation = "https://docs.rs/ector"
 readme = "../README.md"
@@ -15,9 +15,9 @@ exclude = [".github"]
 doctest = false
 
 [dependencies]
-embassy-executor = { version = "0.7", default-features = false }
+embassy-executor = { version = "0.9", default-features = false }
 embassy-sync = { version = "0.7", default-features = false }
-portable-atomic = { version = "1.3", default-features = false }
+portable-atomic = { version = "1.11", default-features = false }
 
 log = { version = "0.4", optional = true }
 defmt = { version = "1.0.1", optional = true }
@@ -28,14 +28,14 @@ static_cell = "2.1"
 
 
 [dev-dependencies]
-embassy-executor = { version = "0.7", default-features = false, features = [
+embassy-executor = { version = "0.9", default-features = false, features = [
     "arch-std",
     "executor-thread",
 ] }
-embassy-time = { version = "0.4", default-features = false, features = [
+embassy-time = { version = "0.5", default-features = false, features = [
     "std",
 ] }
-embassy-futures = "0.1.1"
+embassy-futures = "0.1.2"
 futures = { version = "0.3.31", default-features = false, features = [
     "executor",
 ] }

--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -17,14 +17,15 @@ doctest = false
 [dependencies]
 embassy-executor = { version = "0.9", default-features = false }
 embassy-sync = { version = "0.7", default-features = false }
-portable-atomic = { version = "1.11", default-features = false }
+portable-atomic = { version = "1", default-features = false }
 
 log = { version = "0.4", optional = true }
-defmt = { version = "1.0.1", optional = true }
+defmt = { version = "1", optional = true }
+
+futures = { version = "0.3", default-features = false }
+static_cell = "2"
 
 ector-macros = { version = "0.5.1", path = "../macros" }
-futures = { version = "0.3", default-features = false }
-static_cell = "2.1"
 
 
 [dev-dependencies]

--- a/ector/Cargo.toml
+++ b/ector/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "ector"
 version = "0.9.0"
 description = "Ector is an open source async, no-alloc actor framework for embedded devices."

--- a/ector/build.rs
+++ b/ector/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-	if std::env::var_os("CARGO_FEATURE_NIGHTLY").is_some() {
-		println!("cargo:rustc-cfg=nightly");
-	}
+    if std::env::var_os("CARGO_FEATURE_NIGHTLY").is_some() {
+        println!("cargo:rustc-cfg=nightly");
+    }
 }

--- a/ector/examples/pingpong.rs
+++ b/ector/examples/pingpong.rs
@@ -2,7 +2,7 @@ use {
     ector::*,
     embassy_time::{Duration, Ticker},
     futures::{
-        future::{join, select, Either},
+        future::{Either, join, select},
         pin_mut,
     },
 };

--- a/ector/examples/qmh.rs
+++ b/ector/examples/qmh.rs
@@ -38,7 +38,7 @@ pub mod qmh_actor {
     use core::future::pending;
     use ector::{mutex::NoopRawMutex, *};
     use embassy_executor::SpawnError;
-    use embassy_futures::select::{select, Either};
+    use embassy_futures::select::{Either, select};
     use embassy_sync::channel::Sender;
     use embassy_time::{Duration, Instant, Timer};
 

--- a/ector/src/lib.rs
+++ b/ector/src/lib.rs
@@ -84,9 +84,7 @@ macro_rules! actor {
         )
     }};
 
-    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty) => {{
-        ::ector::actor!($spawner, $name, $ty, $instance, $mutex, 1)
-    }};
+    ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty) => {{ ::ector::actor!($spawner, $name, $ty, $instance, $mutex, 1) }};
 
     ($spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:expr) => {{
         ::ector::actor!(
@@ -129,9 +127,7 @@ macro_rules! spawn_context {
         )
     }};
 
-    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty) => {{
-        ::ector::spawn_context!($context, $spawner, $name, $ty, $instance, $mutex, 1)
-    }};
+    ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $mutex:ty) => {{ ::ector::spawn_context!($context, $spawner, $name, $ty, $instance, $mutex, 1) }};
 
     ($context:ident, $spawner:ident, $name:ident, $ty:ty, $instance:expr, $queue_size:expr) => {{
         ::ector::spawn_context!(

--- a/ector/src/testutils.rs
+++ b/ector/src/testutils.rs
@@ -1,7 +1,7 @@
 use {
     crate::{Actor, DynamicAddress, Inbox},
     core::{cell::RefCell, future::Future, pin::Pin},
-    embassy_executor::{raw, Spawner},
+    embassy_executor::{Spawner, raw},
     embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal},
     portable_atomic::{AtomicBool, Ordering},
     static_cell::StaticCell,

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "ector-macros"
 version = "0.5.1"
 description = "Ector is an open source async, no-alloc actor framework for embedded devices."

--- a/macros/src/actor.rs
+++ b/macros/src/actor.rs
@@ -1,14 +1,14 @@
 use {
     proc_macro2::{Span, TokenStream},
-    quote::{quote, quote_spanned, ToTokens},
+    quote::{ToTokens, quote, quote_spanned},
     syn::{
+        Attribute, Block, FnArg, GenericArgument, GenericParam, ImplItem, ImplItemType, ItemImpl,
+        Lifetime, Pat, Receiver, Signature, Token, Type, TypeReference, WhereClause,
         parse::{Error, Parse, ParseStream, Result},
         parse_quote, parse_quote_spanned,
         punctuated::Punctuated,
         spanned::Spanned,
         visit_mut::{self, VisitMut},
-        Attribute, Block, FnArg, GenericArgument, GenericParam, ImplItem, ImplItemType, ItemImpl,
-        Lifetime, Pat, Receiver, Signature, Token, Type, TypeReference, WhereClause,
     },
 };
 
@@ -96,11 +96,11 @@ impl VisitMut for CollectLifetimes {
         visit_mut::visit_type_reference_mut(self, ty);
     }
 
-    fn visit_generic_argument_mut(&mut self, gen: &mut GenericArgument) {
-        if let GenericArgument::Lifetime(lifetime) = gen {
+    fn visit_generic_argument_mut(&mut self, gen_args: &mut GenericArgument) {
+        if let GenericArgument::Lifetime(lifetime) = gen_args {
             self.visit_lifetime(lifetime);
         }
-        visit_mut::visit_generic_argument_mut(self, gen);
+        visit_mut::visit_generic_argument_mut(self, gen_args);
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -5,7 +5,7 @@ extern crate proc_macro;
 mod actor;
 
 use {
-    actor::{generate_actor, Item},
+    actor::{Item, generate_actor},
     proc_macro::TokenStream,
     quote::quote,
     syn::{

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2021"
+edition = "2024"
 imports_granularity = "One"


### PR DESCRIPTION
Maintenance work for embassy compat.

- Bumped to 0.9 so that the version number matches embassy executor's one.
- Bumped embassy deps
- Reduced version requirements
  - Only major (or minor if no major release yet)
- Bumped edition to 2024
  - Fixed gen reserved keyword
- Ran `cargo fmt` with new edition
- Ran `cargo clippy`
- Ran all tests and examples
